### PR TITLE
Initial /moderndatastores command

### DIFF
--- a/src/main/kotlin/dev/betrix/moderndatastores/ModernDatastores.kt
+++ b/src/main/kotlin/dev/betrix/moderndatastores/ModernDatastores.kt
@@ -1,7 +1,10 @@
 package dev.betrix.moderndatastores
 
+import dev.betrix.moderndatastores.commands.ModernDatastoresCommand
 import dev.betrix.moderndatastores.stores.Store
 import dev.betrix.moderndatastores.utils.DataStore
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
@@ -36,6 +39,16 @@ class ModernDatastores : JavaPlugin() {
         }
     }
 
+    val prefix: Component
+        get() {
+            val unformatted = config.getString("prefix")!!
+            return MiniMessage.miniMessage().deserialize(unformatted)
+        }
+
+    private fun initCommands() {
+        getCommand("moderndatastores")?.setExecutor(ModernDatastoresCommand(this))
+    }
+
     override fun onEnable() {
         saveDefaultConfig()
 
@@ -46,6 +59,10 @@ class ModernDatastores : JavaPlugin() {
             logger.info("PlaceholderAPI detected, Registering expansion")
             ModernDatastoresExpansion(this).register()
         }
+
+        registerStores(this, listOf(DataStore("Hello", "this is a test")))
+
+        initCommands()
 
         logger.info("Modern Datastores Initialized")
     }

--- a/src/main/kotlin/dev/betrix/moderndatastores/ModernDatastoresRegistry.kt
+++ b/src/main/kotlin/dev/betrix/moderndatastores/ModernDatastoresRegistry.kt
@@ -20,23 +20,21 @@ class ModernDatastoresRegistry(private val datastores: ModernDatastores) {
         defaultProvider = provider
         registeredProviders[defaultSolution] = provider
 
-        val customProviderList = datastores.config.get("custom_store_providers") as MemorySection
+        val customProviderList = datastores.config.get("custom_store_providers")
 
-        datastores.logger.info("${customProviderList.getKeys(false)}")
+        if (customProviderList is MemorySection) {
+            for (pluginName in customProviderList.getKeys(false)) {
+                val customPluginProviders = customProviderList.get(pluginName) as MemorySection
 
-        for (pluginName in customProviderList.getKeys(false)) {
-            val customPluginProviders = customProviderList.get(pluginName) as MemorySection
+                for (key in customPluginProviders.getKeys(false)) {
+                    val value = customPluginProviders.get(key) as String
 
-            for (key in customPluginProviders.getKeys(false)) {
-                val value = customPluginProviders.get(key) as String
-
-                if (!registeredProviders.containsKey(value)) {
-                    registeredProviders[value] = getProvider(value)
+                    if (!registeredProviders.containsKey(value)) {
+                        registeredProviders[value] = getProvider(value)
+                    }
                 }
             }
         }
-
-        datastores.logger.info("$registeredProviders")
     }
 
     private fun getProvider(name: String): Provider {

--- a/src/main/kotlin/dev/betrix/moderndatastores/commands/ModernDatastoresCommand.kt
+++ b/src/main/kotlin/dev/betrix/moderndatastores/commands/ModernDatastoresCommand.kt
@@ -1,0 +1,101 @@
+package dev.betrix.moderndatastores.commands
+
+import dev.betrix.moderndatastores.ModernDatastores
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.minimessage.MiniMessage
+import org.bukkit.Bukkit
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+import org.bukkit.entity.Player
+
+class ModernDatastoresCommand(private val datastores: ModernDatastores) : CommandExecutor, TabCompleter {
+
+    private val prefix = datastores.prefix
+
+    private fun handleListCommand(sender: Player, args: List<String>) {
+        if (args.isEmpty()) {
+            // Line breaks are positioned in a way to give a 1 line vertical padding between the list and other text
+            val message = Component.text().append(prefix)
+                    .append(Component.text()
+                            .content(
+                                    " Below is a list of all plugins using Datastores, click one to view its stores.\n\n")
+                            .color(NamedTextColor.GOLD))
+
+            for (registeredPlugin in ModernDatastores.registry.registeredStores.keys.toList()) {
+                val miniMessage = " <dark_gray>- <dark_aqua>[<aqua>$registeredPlugin</aqua>]</dark_aqua>\n"
+
+                message.append(MiniMessage.miniMessage().deserialize(miniMessage)
+                        .clickEvent(ClickEvent.runCommand("/moderndatastores list $registeredPlugin")))
+                        .hoverEvent(
+                                HoverEvent.showText(Component.text("Click to show stores for $registeredPlugin")
+                                        .color(NamedTextColor.AQUA)))
+            }
+
+            sender.sendMessage(message.build())
+        } else {
+            val stores = ModernDatastores.registry.registeredStores[args[0]]
+
+            if (stores != null) {
+                val message = Component.text().append(prefix.append(MiniMessage.miniMessage()
+                        .deserialize(
+                                " <gold>Below is a list of all stores used in <yellow>${args[0]}</yellow>.</gold>\n\n")))
+
+                for (store in stores.values) {
+                    datastores.logger.info("$store")
+                    message.append(MiniMessage.miniMessage().deserialize(
+                            " <dark_gray>- <dark_aqua>[<aqua>${store.name}</aqua>]</dark_aqua><dark_gray>: <yellow>${store.description}\n"))
+                }
+
+                sender.sendMessage(message)
+            } else {
+                val validPlugin = Bukkit.getPluginManager().getPlugin(args[0])
+
+                if (validPlugin == null) {
+                    val message = prefix.append(Component.text(" ${args[0]} is not a valid plugin name. Please use ")
+                            .color(NamedTextColor.RED)
+                            .append(Component.text("/moderndatastores list ").color(NamedTextColor.AQUA).clickEvent(
+                                    ClickEvent.runCommand("/moderndatastores list")).hoverEvent(HoverEvent.showText(
+                                    Component.text("Click to run the command").color(NamedTextColor.AQUA))))
+                            .append(Component.text("for a list of valid plugins.").color(NamedTextColor.RED)))
+
+
+                    sender.sendMessage(message)
+                } else {
+                    val message = Component.text("${validPlugin.name} does not have any registered stores.")
+                            .color(NamedTextColor.RED)
+
+                    sender.sendMessage(message)
+                }
+            }
+        }
+    }
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        if (sender !is Player) return true
+
+        if (args[0] == "list") {
+            handleListCommand(sender, args.toList().subList(1, args.size))
+        }
+
+        return true
+    }
+
+    override fun onTabComplete(sender: CommandSender, command: Command, label: String, args: Array<String>): List<String>? {
+        val listArgs = args.toList()
+
+        if (listArgs.size == 1) {
+            return listOf("list")
+        }
+
+        if (listArgs.contains("list")) {
+            return ModernDatastores.registry.registeredStores.keys.toList()
+        }
+
+        return null
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,8 @@
 # Modern Datastores
 
+# Prefix that is shown before messages
+prefix: "<dark_gray>[<gradient:#29a9ff:#82cdff>Modern</gradient> <gradient:#82cdff:#29a9ff>Datastores</gradient>]"
+
 # What database solution to use
 # Possible options:
 # - "YAML": The easiest solution. Stored in '/plugins/ModernDatastores/'. Certain operations may be slower than other solutions.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,9 @@ authors: [ Betrix ]
 description: A simple solution to handling persistent data storage in your Minecraft server.
 softdepend:
   - PlaceholderAPI
+commands:
+  moderndatastores:
+    description: Utility command for interacting with ModernDatastores
+    aliases:
+      - md
+    permission: moderndatastores.command


### PR DESCRIPTION
### This pull request adds the initial `/moderndatastores` or `/md` command to the plugin. 
 *This pr also fixes a bug where if `custom_store_providers` was empty in `config.yml`, the type cast would fail.*

The current functionality implements the `/md list` sub-command to allow server owners to list out all plugins that use Datastores, and each store that is used within that plugin.
This allows server owners to figure out which stores they want to store apart from others in a easier way.

## Command Images

`/moderndatastores list` Where ModernDatastores is also a plugin that has a registered store.
![md_list](https://user-images.githubusercontent.com/53540292/201511997-48b4d266-9185-4539-83a0-26cb0da8e5e7.png)
![md_list_hover](https://user-images.githubusercontent.com/53540292/201511998-61089ab6-03f7-45b0-b026-bc1f80524de6.png)

`/moderndatastores list ModernDatastores` Where **Hello** is a store name and **this is a test** is the description for that store.
![md_list_plugin](https://user-images.githubusercontent.com/53540292/201511999-597237bd-4ac2-4830-84c0-92c5ce26b7e2.png)
